### PR TITLE
Fix created value be none

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ pip install liege
 
 You can read the following datasets with this package:
 
-- Disabled parking spaces / Stationnement PMR (950 locations)
-- Garages / Les parkings voitures hors voirie (10 locations)
+- [Disabled parking spaces / Stationnement PMR][disabled_parking] (952 locations)
+- [Garages / Les parkings voitures hors voirie][garages] (26 locations)
 
 <details>
     <summary>Click here to get more details</summary>
@@ -193,6 +193,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 [api]: https://opendata.liege.be/explore
+[disabled_parking]: https://opendata.liege.be/explore/dataset/stationnement-pmr
+[garages]: https://opendata.liege.be/explore/dataset/parkings-voitures-hors-voirie
 [nipkaart]: https://www.nipkaart.nl
 
 <!-- MARKDOWN LINKS & IMAGES -->

--- a/liege/models.py
+++ b/liege/models.py
@@ -51,8 +51,8 @@ class Garage:
             url=attr.get("website"),
             longitude=geo[0],
             latitude=geo[1],
-            created_at=datetime.strptime(attr.get("created"), "%Y-%m-%d"),
-            updated_at=datetime.strptime(attr.get("last_modified"), "%Y-%m-%d"),
+            created_at=strptime(attr.get("created"), "%Y-%m-%d"),
+            updated_at=strptime(attr.get("last_modified"), "%Y-%m-%d"),
         )
 
 
@@ -70,7 +70,7 @@ class DisabledParking:
     longitude: float
     latitude: float
 
-    created_at: datetime
+    created_at: datetime | None
     updated_at: datetime
 
     @classmethod
@@ -95,6 +95,23 @@ class DisabledParking:
             status=attr.get("status"),
             longitude=geo[0],
             latitude=geo[1],
-            created_at=datetime.strptime(attr.get("created"), "%Y-%m-%d"),
-            updated_at=datetime.strptime(attr.get("last_modified"), "%Y-%m-%d"),
+            created_at=strptime(attr.get("created"), "%Y-%m-%d"),
+            updated_at=strptime(attr.get("last_modified"), "%Y-%m-%d"),
         )
+
+
+def strptime(date_string: str, date_format: str, default: None = None) -> Any:
+    """Strptime function with default value.
+
+    Args:
+        date_string: The date string.
+        date_format: The format of the date string.
+        default: The default value.
+
+    Returns:
+        The datetime object.
+    """
+    try:
+        return datetime.strptime(date_string, date_format)
+    except (ValueError, TypeError):
+        return default

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-"""Asynchronous Python client providing Open Data information of Gent."""
+"""Asynchronous Python client providing Open Data information of Liege."""
 import os
 
 

--- a/tests/fixtures/disabled_parkings.json
+++ b/tests/fixtures/disabled_parkings.json
@@ -366,7 +366,6 @@
                 "gid": 1257,
                 "municipality": "Liège",
                 "street_name": "place des Abeilles",
-                "created": "2021-03-25",
                 "geo_shape": {
                     "coordinates": [
                         5.6330619893,


### PR DESCRIPTION
The code breaks when the `created` value is **none**. With this adjustment, the value can now also be none without any problems. Also updating the documentation with the latest numbers of items.