### PR TITLE
Change value for spot_id because not unique

### DIFF
--- a/liege/models.py
+++ b/liege/models.py
@@ -60,7 +60,7 @@ class Garage:
 class DisabledParking:
     """Object representing a disabled parking."""
 
-    spot_id: int
+    spot_id: str
     number: int
     address: str
     municipality: str
@@ -87,7 +87,7 @@ class DisabledParking:
         attr = data["fields"]
         geo = data["geometry"]["coordinates"]
         return cls(
-            spot_id=attr.get("icar_address_id"),
+            spot_id=str(data.get("recordid")),
             number=attr.get("available_spaces"),
             address=f"{attr.get('street_name')} {attr.get('house_number')}, {attr.get('postal_code')}",
             municipality=attr.get("municipality"),

--- a/test_output.py
+++ b/test_output.py
@@ -11,13 +11,22 @@ async def main() -> None:
     async with ODPLiege() as client:
         garages = await client.garages(limit=12)
         disabled_parkings = await client.disabled_parkings(limit=5)
-        print(disabled_parkings)
+        print(garages)
 
         count: int
-        for index, item in enumerate(garages, 1):
+        for index, item in enumerate(disabled_parkings, 1):
             count = index
             print(item)
-        print(f"{count} locations found")
+
+        # Count unique id's in disabled_parkings
+        unique_values: list[str] = []
+        for item in disabled_parkings:
+            unique_values.append(item.spot_id)
+        num_values = len(set(unique_values))
+
+        print("__________________________")
+        print(f"Total locations found: {count}")
+        print(f"Unique ID values: {num_values}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It turned out that the previously used `spot_id` value was not unique enough, so now a different value has been chosen from the data and **test_output.py** has extra code to count how many unique ids there are.